### PR TITLE
Input bug fix: no initial input value

### DIFF
--- a/packages/web/src/Form/Input/Input.js
+++ b/packages/web/src/Form/Input/Input.js
@@ -37,7 +37,7 @@ export default class Input extends React.Component<Props, State> {
     size: 'Small',
   };
   state = {
-    value: this.props.value,
+    value: this.props.value || '',
   };
   input: any;
 

--- a/packages/web/src/Form/TextArea/TextArea.js
+++ b/packages/web/src/Form/TextArea/TextArea.js
@@ -28,7 +28,7 @@ type State = {
 
 export default class TextArea extends React.Component<Props, State> {
   state = {
-    value: this.props.value,
+    value: this.props.value || '',
   };
 
   input: any;


### PR DESCRIPTION
Fix #39 

Add empty string if possible no props value in `Input`, and `TextArea`