### PR TITLE
Turn off some eslint rules might conflict with Prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,11 @@
 {
-  "extends": ["@gssfed", "prettier", "plugin:flowtype/recommended"],
+  "extends": [
+    "@gssfed",
+    "plugin:flowtype/recommended",
+    "prettier",
+    "prettier/flowtype",
+    "prettier/react"
+  ],
   "plugins": [
     "react",
     "flowtype",


### PR DESCRIPTION
The following eslint rules are conflicted with Prettier:
```
- flowtype/generic-spacing
- flowtype/space-after-type-colon
- flowtype/space-before-generic-bracket
- flowtype/space-before-type-colon
- flowtype/union-intersection-spacing
- react/jsx-closing-bracket-location
- react/jsx-closing-tag-location
- react/jsx-curly-spacing
- react/jsx-equals-spacing
- react/jsx-first-prop-new-line
- react/jsx-indent
- react/jsx-indent-props
- react/jsx-max-props-per-line
- react/jsx-tag-spacing
- react/jsx-wrap-multilines
```